### PR TITLE
The link is broken

### DIFF
--- a/running-on-aws/ami-using-cloudformation.md
+++ b/running-on-aws/ami-using-cloudformation.md
@@ -9,7 +9,7 @@ All the resources required to create and configure LOGIQ on AWS are taken care b
 The CloudFormation template can be found below
 
 ```text
-https://logiqcf.s3.amazonaws.com/release/logiq-stack.json
+https://logiqcf.s3.amazonaws.com/releases/logiq-stack.json
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
The CF template should be pointing towards the below 
https://logiqcf.s3.amazonaws.com/releases/logiq-stack.json
but its being pointed towards the release folder, there is no folder called release on s3
https://logiqcf.s3.amazonaws.com/release/logiq-stack.json