### PR TITLE
CF templates no accessible due to spell error

### DIFF
--- a/running-on-aws/ami-using-cloudformation.md
+++ b/running-on-aws/ami-using-cloudformation.md
@@ -9,7 +9,7 @@ All the resources required to create and configure LOGIQ on AWS are taken care b
 The CloudFormation template can be found below
 
 ```text
-https://logiqcf.s3.amazonaws.com/release/logiq-stack.json
+https://logiqcf.s3.amazonaws.com/releases/logiq-stack.json
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
CF templates no accessible due to spell error 

From: https://logiqcf.s3.amazonaws.com/release/logiq-stack.json
Changed to : https://logiqcf.s3.amazonaws.com/releases/logiq-stack.json