### PR TITLE
added -e parameter to run docker without error

### DIFF
--- a/logiq-server/agentless.md
+++ b/logiq-server/agentless.md
@@ -382,7 +382,7 @@ Sending data from docker to LOGIQ using TCP and non TLS port can be done as belo
 
 ```text
 docker run --log-driver syslog \
---log-opt syslog-address=tcp://logiqserver-devtest.example.com:514 \
+--log-opt syslog-address=tcp://logiqserver-devtest.example.com:514 -e MYSQL_ROOT_PASSWORD=pass \
 --log-opt syslog-format=rfc3164 --log-opt tag=mysql --name mysql3 -d mysql
 ```
 
@@ -392,7 +392,7 @@ When using to connect to LOGIQ TLS port in a secured setup, pass the client cert
 
 ```text
 docker run --log-driver syslog \
---log-opt syslog-address=tcp://logiqserver-devtest.example.com:514 \
+--log-opt syslog-address=tcp://logiqserver-devtest.example.com:514  -e MYSQL_ROOT_PASSWORD=pass\
 --log-opt syslog-tls-cert=client.pem --log-opt syslog-tls-key=key.pem \
 --log-opt syslog-tls-ca-cert=ca.pem --log-opt syslog-format=rfc3164 \
 --log-opt tag=mysql --name mysql3 -d mysql


### PR DESCRIPTION
Added the -e MYSQL_ROOT_PASSWORD=pass in docker run.

docker run --log-driver syslog \
--log-opt syslog-address=tcp://logiqserver-devtest.example.com:514 -e MYSQL_ROOT_PASSWORD=pass \
--log-opt syslog-format=rfc3164 --log-opt tag=mysql --name mysql3 -d mysql